### PR TITLE
Fix code scanning alert no. 8: Incomplete regular expression for hostnames

### DIFF
--- a/apps/nirina-site/tests/tests.spec.ts
+++ b/apps/nirina-site/tests/tests.spec.ts
@@ -15,7 +15,7 @@ test('get started link', async ({ page }) => {
   await page.getByRole('link', { name: /LinkedIn/ }).click()
 
   // Expects page to have a heading with the name of Installation.
-  await expect(page).toHaveURL(/https:\/\/www.linkedin.com\/*/)
+  await expect(page).toHaveURL(/https:\/\/www\.linkedin\.com\/*/)
 })
 
 test.skip("affiche le titre d'un article et permet de cliquer dessus", async ({


### PR DESCRIPTION
Fixes [https://github.com/Seboran/monorepo/security/code-scanning/8](https://github.com/Seboran/monorepo/security/code-scanning/8)

To fix the problem, we need to escape the `.` character in the regular expression to ensure it matches only a literal `.` and not any character. This can be done by replacing `.` with `\.` in the regular expression. This change will ensure that only URLs with the exact domain `www.linkedin.com` are matched.

The specific change needed is on line 18 of the file `apps/nirina-site/tests/tests.spec.ts`. We need to update the regular expression from `https:\/\/www.linkedin.com\/*` to `https:\/\/www\.linkedin\.com\/*`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
